### PR TITLE
Add `vault-cli` provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.dll
 *.exe
 .idea/
+*.iml
 *.ipr
 example.tf
 bin/
@@ -12,4 +13,4 @@ examples/tfstate-encrypt/*.tfstate*
 *.bak
 *~
 .*.swp
-
+/terrahelp-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.4.1 (Unreleased)
+* Add new `vault-cli` provider to use the `vault` command line tool rather than talking to the vault API. 
 
 ## 0.4.0
 **Note: This release contains breaking changes!!**

--- a/main.go
+++ b/main.go
@@ -37,6 +37,12 @@ func newTerraHelperFunc() func(provider string) *terrahelp.CryptoHandler {
 				exitIfError(err)
 			}
 			return &terrahelp.CryptoHandler{Encrypter: e}
+		case (provider == terrahelp.ThEncryptProviderVaultCli):
+			e, err := terrahelp.NewVaultCliEncrypter()
+			if err != nil {
+				exitIfError(err)
+			}
+			return &terrahelp.CryptoHandler{Encrypter: e}
 		}
 
 		exitIfError(fmt.Errorf("Invalid provider %s specified ", provider))

--- a/terrahelp/crypto.go
+++ b/terrahelp/crypto.go
@@ -57,6 +57,7 @@ const (
 const (
 	ThEncryptProviderSimple = "simple"
 	ThEncryptProviderVault  = "vault"
+	ThEncryptProviderVaultCli  = "vault-cli"
 )
 
 // Valid encryption modes
@@ -72,6 +73,8 @@ func (o *CryptoHandlerOpts) getEncryptionKey() string {
 	case (o.EncProvider == ThEncryptProviderSimple):
 		return o.SimpleKey
 	case (o.EncProvider == ThEncryptProviderVault):
+		return o.NamedEncKey
+	case (o.EncProvider == ThEncryptProviderVaultCli):
 		return o.NamedEncKey
 	default:
 		return ""
@@ -91,7 +94,7 @@ func (o *CryptoHandlerOpts) ValidateForEncryptDecrypt() error {
 			"The simple provider uses AES and so the AES key should be either 16 or 32 byte to select AES-128 or AES-256 encryption")
 
 	}
-	if o.EncProvider == ThEncryptProviderVault && o.NamedEncKey == "" {
+	if (o.EncProvider == ThEncryptProviderVault || o.EncProvider == ThEncryptProviderVaultCli) && o.NamedEncKey == "" {
 		return fmt.Errorf("You must supply a vault-namedkey when using the vault provider ")
 	}
 	return nil

--- a/terrahelp/encrypter.go
+++ b/terrahelp/encrypter.go
@@ -89,6 +89,15 @@ func NewVaultEncrypter() (*VaultEncrypter, error) {
 	return createVaultEncrypter(vc)
 }
 
+func NewVaultCliEncrypter() (*VaultEncrypter, error) {
+	var vc VaultClient
+	vc, err := NewVaultCliClient()
+	if err != nil {
+		return nil, err
+	}
+	return &VaultEncrypter{vc}, nil
+}
+
 func createVaultEncrypter(vc VaultClient) (*VaultEncrypter, error) {
 	return &VaultEncrypter{vc}, nil
 }

--- a/terrahelp/vault_cli_client.go
+++ b/terrahelp/vault_cli_client.go
@@ -1,0 +1,136 @@
+package terrahelp
+
+import (
+	"encoding/json"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+type VaultCliClient struct {
+}
+
+type vaultOutput struct
+{
+	Data map[string]string `json:"data"`
+}
+
+var _ VaultClient = &VaultCliClient{}
+
+func NewVaultCliClient() (*VaultCliClient, error) {
+
+	return &VaultCliClient{}, nil
+}
+
+// MountTransitBackend ensures the transit backend is mounted
+func (v *VaultCliClient) MountTransitBackend() error {
+	exists, err := v.transitMountExists()
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		log.Println("Mounting transit backend ... ")
+		_, err := exec.Command("vault", "mount", "-path=transit", "transit").Output()
+		if err != nil {
+			return err
+		}
+	} else {
+		log.Println("transit backend already exists ... ")
+	}
+	return nil
+}
+
+// RegisterNamedEncryptionKey registers the named encryption key
+// within Vault's transit backend
+func (v *VaultCliClient) RegisterNamedEncryptionKey(key string) error {
+	exists, err := v.namedEncryptionKeyExists(key)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		log.Printf("Named encryption key '%s' does not exist, creating at %s ... ", key, v.encryptKeyPath(key))
+
+		_, e := exec.Command("vault", "write", v.encryptKeyPath(key)).Output()
+		return e
+	}
+
+	log.Printf("Named encryption key '%s' already exists at %s ... ", key, v.encryptKeyPath(key))
+	return nil
+}
+
+func (v *VaultCliClient) transitMountExists() (bool, error) {
+
+	out, err := exec.Command("vault", "mounts").Output()
+
+	if err != nil {
+		return false, err
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if fields[0] == "transit/" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (v *VaultCliClient) namedEncryptionKeyExists(key string) (bool, error) {
+	_, err := exec.Command("vault", "read", key).Output()
+
+	switch err.(type) {
+	case nil:
+		return true, nil
+	case (*exec.ExitError):
+		var exitError *exec.ExitError = err.(*exec.ExitError)
+		if strings.HasPrefix(string(exitError.Stderr), "No value found at") {
+			return false, nil
+		}
+		return false, err
+	default:
+		return false, err
+	}
+
+}
+
+// Decrypt uses the named encryption key to decrypt the supplied content
+func (v *VaultCliClient) Decrypt(key, ciphertext string) (string, error) {
+	return v.transit(v.decryptEndpoint(key), "ciphertext", ciphertext, "plaintext")
+}
+
+// Encrypt uses the named encryption key to encrypt the supplied content
+func (v *VaultCliClient) Encrypt(key, b64text string) (string, error) {
+	return v.transit(v.encryptEndpoint(key), "plaintext" , b64text, "ciphertext")
+}
+
+func (v *VaultCliClient) transit(key, inputField, value, expectedField string) (string, error) {
+	cmd := exec.Command("vault", "write", "-format=json", key, inputField + "=-")
+	cmd.Stdin = strings.NewReader(value)
+	out, err := cmd.Output()
+
+	if err != nil {
+		log.Printf("error occurred %s", cmd.Args)
+		return "", err
+	}
+
+	output := &vaultOutput{}
+
+	json.Unmarshal(out, output)
+
+	return output.Data[expectedField], nil
+}
+
+func (v *VaultCliClient) encryptKeyPath(key string) string {
+	return "/transit/keys/" + key
+}
+
+func (v *VaultCliClient) encryptEndpoint(key string) string {
+	return "/transit/encrypt/" + key
+}
+
+func (v *VaultCliClient) decryptEndpoint(key string) string {
+	return "/transit/decrypt/" + key
+}

--- a/terrahelp/vaultclient.go
+++ b/terrahelp/vaultclient.go
@@ -23,9 +23,6 @@ type VaultClient interface {
 	Encrypt(key, text string) (string, error)
 	// Decrypt uses the named encryption key to decrypt the supplied content
 	Decrypt(key, ciphertext string) (string, error)
-
-	transitMountExists() (bool, error)
-	namedEncryptionKeyExists(key string) (bool, error)
 }
 
 // DefaultVaultClient provides a wrapper around the core Vault
@@ -43,7 +40,10 @@ func NewDefaultVaultClient() (*DefaultVaultClient, error) {
 			"\n  please configure these before continuing.")
 	}
 	vc := api.DefaultConfig()
-	vc.ReadEnvironment()
+	err := vc.ReadEnvironment()
+	if err != nil {
+		return nil, fmt.Errorf("Issue getting client : %s", err)
+	}
 	vclient, err := api.NewClient(vc)
 	if err != nil {
 		return nil, fmt.Errorf("Issue getting client : %s", err)


### PR DESCRIPTION
Add provider which uses the Vault command line tool to talk to Vault rather than the Vault API to work around issues where some users are getting TCP connection reset issues.