### PR TITLE
Updates Makefile and README.md to introduce new targets.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ examples/tfstate-encrypt/*.tfstate*
 .*.swp
 /terrahelp-*
 .envrc
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ sudo: false
 env:
   global:
     - NAME=terrahelp
-go:
-  - 1.13.x
-  - tip
 install: true
-matrix:
+jobs:
+  include:
+    - go: 1.13.x
+    - go: tip
+      env: SKIP_GO_REQ_VERSION_CHECK=1
   allow_failures:
     - go: tip
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 sudo: false
 env:
   global:
-    - TARGET=terrahelp
+    - NAME=terrahelp
 go:
   - 1.13.x
   - tip
@@ -21,7 +21,7 @@ deploy:
     secure: nmky4Q4ayz8l4+rvlVAzU0Q+ixeQZZxXOPTj3fJiGx5/AX29qSLfPqV6NVB8qAzu5j7W7mjb7LWB5Tt0qyLAmHXd7N5XCLh+8ecpTvdzBqnJ/M67wV/j89Yq3pNCEYmhyu2NRGovz1cCifGTIG51aCJg2vZjdVpeqGC1WUKHk6lewO9f6hx21q05it8q+1KvFIFPMEKajtfm+nx8xkh9LdrDZTjh+r8E9Orqr9L64Ij3HUv5lWcxZ/5L83rO60dSQukPuAs+ex5ELK9+Am6T3aSyRUckBx1U91tB8dXF5hy9TSxyLgZZAaMiZORfEgKM5tNIiXhDhbf3Jt2wnm0vCHWjyxRilmfxQLXvDumn5mogr3piGKNdooufcHxT6zm5n/74JfhGf4kk1zOQ4Mk2xltnQxy0T18GfoshiCCLr7o3io+PR3RqAx6HwwpHKwj3UWujK+HbBmhSrNfjzvIK42BGLorwdPVKNXb89ZU30RP13XxfyH1W9O70e81VEeQ8WaEyprsmjtbuiKMk+uv5WxUY6fNCfxq2ozFH3oVgcgeAIsB99Ka/8u1DQ2c1flhRXwUW+RuZlOkvp8mwMZAVl7xbdYF0n6rsYAcZZpnnQoKj1s8LcfR9a+aXvTcQtpz6vY4D1GJOHEWyMp6WiBA3XdKAtqX3tGOLW95D45gdoxw=
   file_glob: true
   file:
-    - $TARGET-*
+    - dist/$NAME-*
   skip_cleanup: true
   on:
     repo: opencredo/$TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ matrix:
   allow_failures:
     - go: tip
 script:
-  - make check
-  - make test
+  - make build
 after_success:
   - make dist
 deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.7.2 (unreleased)
+* [PR-25](https://github.com/opencredo/terrahelp/pull/25) Updates Makefile and README.md to introduce new targets (resolves [#24](https://github.com/opencredo/terrahelp/issues/24))
 
 ## 0.7.1
 * [PR-21](https://github.com/opencredo/terrahelp/pull/21) Updates Travis deploy credentials for Github releases (resolved [#20](https://github.com/opencredo/terrahelp/issues/20))

--- a/Makefile
+++ b/Makefile
@@ -76,20 +76,20 @@ dist: $(PLATFORMS)
 
 .PHONY: dependencies
 dependencies:
-	@ echo "==> Downloading dependencies for $(TARGET)"
+	@ echo "==> Downloading dependencies for $(NAME)"
 	@ go mod download
 
 .PHONY: vendor-dependencies
 vendor-dependencies:
-	@ echo "==> Downloading dependencies for $(TARGET)"
+	@ echo "==> Downloading dependencies for $(NAME)"
 	@ go mod vendor
 
 .PHONY: tidy-dependencies
 tidy-dependencies:
-	@ echo "==> Tidying dependencies for $(TARGET)"
+	@ echo "==> Tidying dependencies for $(NAME)"
 	@ go mod tidy
 
 .PHONY: clean-dependencies
 clean-dependencies:
-	@ echo "==> Cleaning dependencies for $(TARGET)"
+	@ echo "==> Cleaning dependencies for $(NAME)"
 	@ rm -rf $(VENDOR)

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ build:
 	go build $(BUILDARGS) -o bin/$(NAME)
 
 .PHONY: install
-install:
-	go build $(BUILDARGS) -o ${GOPATH}/bin/$(NAME)
+install: build
+	cp bin/$(NAME) ${GOPATH}/bin/$(NAME)
 
 .PHONY: uninstall
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -12,62 +12,62 @@ PLATFORMS ?= darwin linux
 ARCH ?= amd64
 OS = $(word 1, $@)
 
-check:
-	go vet $(BUILDARGS) ./...
 .PHONY: check
+check:
+	go vet (BUILDARGS) ./...
 
+.PHONY: test
 test:
 	go test $(BUILDARGS) -v ./...
-.PHONY: test
 
+.PHONY: build
 build:
 	go build $(BUILDARGS) -o bin/$(NAME)
-.PHONY: build
 
+.PHONY: install
 install:
 	go build $(BUILDARGS) -o ${GOPATH}/bin/$(NAME)
-.PHONY: install
 
+.PHONY: uninstall
 uninstall:
 	@ echo "==> Uninstalling $(NAME)"
 	rm -f $$(which ${NAME})
-.PHONY: uninstall
 
+.PHONY: clean
 clean:
 	@ echo "==> Cleaning output files."
 ifneq ($(OUPUT_FILES),)
 	rm -rf $(OUPUT_FILES)
 endif
-.PHONY: clean
 
+.PHONY: $(PLATFORMS)
 $(PLATFORMS):
 	@ echo "==> Building $(OS) distribution"
 	@ mkdir -p $(BIN)/$(OS)/$(ARCH)
 	@ mkdir -p $(DIST)
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build $(BUILDARGS) -o $(BIN)/$(OS)/$(ARCH)/$(NAME)
 	cp -f $(BIN)/$(OS)/$(ARCH)/$(NAME) $(DIST)/$(NAME)-$(OS)-$(ARCH)
-.PHONY: $(PLATFORMS)
 
+.PHONY: dist
 dist: $(PLATFORMS)
 	@ true
-.PHONY: dist
 
+.PHONY: dependencies
 dependencies:
 	@ echo "==> Downloading dependencies for $(TARGET)"
 	@ go mod download
-.PHONY: dependencies
 
+.PHONY: vendor-dependencies
 vendor-dependencies:
 	@ echo "==> Downloading dependencies for $(TARGET)"
 	@ go mod vendor
-.PHONY: vendor-dependencies
 
+.PHONY: tidy-dependencies
 tidy-dependencies:
 	@ echo "==> Tidying dependencies for $(TARGET)"
 	@ go mod tidy
-.PHONY: tidy-dependencies
 
+.PHONY: clean-dependencies
 clean-dependencies:
 	@ echo "==> Cleaning dependencies for $(TARGET)"
 	@ rm -rf $(VENDOR)
-.PHONY: clean-dependencies

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ NAME ?= terrahelp
 
 BUILDARGS ?= -mod=vendor
 
+# Set to 1 to skip Go version check in the ensure-version target.
+# This is useful when we want to build using development versions of Go.
+SKIP_GO_REQ_VERSION_CHECK ?= 0
+
 REQ_GO_VERSION := 1.13
 GO_VERSION := $(shell go version | sed -E 's/^go version go([0-9]+.[0-9]+.[0-9]+).*$$/\1/')
 MAX_GO_VERSION := $(shell printf "%s\n%s" $(REQ_GO_VERSION) $(GO_VERSION) | sort -V -r | head -1)
@@ -18,12 +22,17 @@ OS = $(word 1, $@)
 
 .PHONY: ensure-version
 ensure-version:
+ifeq ($(SKIP_GO_REQ_VERSION_CHECK),1)
+	@ echo "==> Skipping go version check"
+else
 	@ echo -n "==> Checking go version... "
 ifeq ($(GO_VERSION),$(MAX_GO_VERSION))
 	@ echo "OK!"
 else
 	@ $(error Found go $(GO_VERSION) but we require $(REQ_GO_VERSION))
 endif
+endif
+
 
 .PHONY: check
 check:

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test:
 	go test $(BUILDARGS) -v ./...
 
 .PHONY: build
-build: ensure-version dependencies check test
+build: ensure-version check test
 	go build $(BUILDARGS) -o bin/$(NAME)
 
 .PHONY: install
@@ -63,7 +63,7 @@ ifneq ($(OUPUT_FILES),)
 endif
 
 .PHONY: $(PLATFORMS)
-$(PLATFORMS): ensure-version dependencies check test
+$(PLATFORMS): ensure-version check test
 	@ echo "==> Building $(OS) distribution"
 	@ mkdir -p $(BIN)/$(OS)/$(ARCH)
 	@ mkdir -p $(DIST)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ BUILDARGS ?= -mod=vendor
 
 REQ_GO_VERSION := 1.13
 GO_VERSION := $(shell go version | sed -E 's/^go version go([0-9]+.[0-9]+.[0-9]+).*$$/\1/')
+MAX_GO_VERSION := $(shell printf "%s\n%s" $(REQ_GO_VERSION) $(GO_VERSION) | sort -V -r | head -1)
 
 BIN := $(CURDIR)/bin
 DIST := $(CURDIR)/dist
@@ -18,7 +19,7 @@ OS = $(word 1, $@)
 .PHONY: ensure-version
 ensure-version:
 	@ echo -n "==> Checking go version... "
-ifneq (,$(findstring $(REQ_GO_VERSION),$(GO_VERSION)))
+ifeq ($(GO_VERSION),$(MAX_GO_VERSION))
 	@ echo "OK!"
 else
 	@ $(error Found go $(GO_VERSION) but we require $(REQ_GO_VERSION))

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,73 @@
+SHELL := /bin/bash
+
+NAME ?= terrahelp
+
 BUILDARGS ?= -mod=vendor
+
+BIN := $(CURDIR)/bin
+DIST := $(CURDIR)/dist
+OUPUT_FILES := $(BIN) $(DIST)
+
+PLATFORMS ?= darwin linux
+ARCH ?= amd64
+OS = $(word 1, $@)
 
 check:
 	go vet $(BUILDARGS) ./...
+.PHONY: check
 
 test:
 	go test $(BUILDARGS) -v ./...
+.PHONY: test
 
 build:
-	go build $(BUILDARGS) -o ${GOPATH}/bin/terrahelp
+	go build $(BUILDARGS) -o bin/$(NAME)
+.PHONY: build
 
-dist:
-	- GOOS=darwin GOARCH=amd64 go build $(BUILDARGS) -o=terrahelp-darwin-amd64
-	- GOOS=linux GOARCH=amd64 go build $(BUILDARGS) -o=terrahelp-linux-amd64
+install:
+	go build $(BUILDARGS) -o ${GOPATH}/bin/$(NAME)
+.PHONY: install
+
+uninstall:
+	@ echo "==> Uninstalling $(NAME)"
+	rm -f $$(which ${NAME})
+.PHONY: uninstall
+
+clean:
+	@ echo "==> Cleaning output files."
+ifneq ($(OUPUT_FILES),)
+	rm -rf $(OUPUT_FILES)
+endif
+.PHONY: clean
+
+$(PLATFORMS):
+	@ echo "==> Building $(OS) distribution"
+	@ mkdir -p $(BIN)/$(OS)/$(ARCH)
+	@ mkdir -p $(DIST)
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build $(BUILDARGS) -o $(BIN)/$(OS)/$(ARCH)/$(NAME)
+	cp -f $(BIN)/$(OS)/$(ARCH)/$(NAME) $(DIST)/$(NAME)-$(OS)-$(ARCH)
+.PHONY: $(PLATFORMS)
+
+dist: $(PLATFORMS)
+	@ true
+.PHONY: dist
+
+dependencies:
+	@ echo "==> Downloading dependencies for $(TARGET)"
+	@ go mod download
+.PHONY: dependencies
+
+vendor-dependencies:
+	@ echo "==> Downloading dependencies for $(TARGET)"
+	@ go mod vendor
+.PHONY: vendor-dependencies
+
+tidy-dependencies:
+	@ echo "==> Tidying dependencies for $(TARGET)"
+	@ go mod tidy
+.PHONY: tidy-dependencies
+
+clean-dependencies:
+	@ echo "==> Cleaning dependencies for $(TARGET)"
+	@ rm -rf $(VENDOR)
+.PHONY: clean-dependencies

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![ReportCard][ReportCard-Image]][ReportCard-Url]
 
 # Terrahelp
-##### terraforming, with a little help from your friends
+##### Terraforming, with a little help from your friends
 
-`terrahelp` is as a command line utility written in [Go](https://github.com/golang/go) and is aimed at 
+Terrahelp is as a command line utility written in [Go](https://golang.org) and is aimed at 
 providing supplementary functionality which can sometimes prove useful when working with 
 [Terraform](https://www.terraform.io). 
 
@@ -30,7 +30,7 @@ Additionally the blog post [Securing Terraform State with Vault](https://www.ope
            terrahelp [global options] command [command options] [arguments...]
 
         VERSION:
-           0.4.3
+           X.X.X
 
         AUTHOR(S):
            https://github.com/opencredo OpenCredo - Nicki Watt
@@ -51,9 +51,9 @@ Additionally the blog post [Securing Terraform State with Vault](https://www.ope
 
 ### Pre-built binaries
 
-Available from this repository's releases page [here](https://github.com/opencredo/terrahelp/releases/).
+Available from the Terrahelp repository's [releases page](https://github.com/opencredo/terrahelp/releases)
 
-The community has also made it available as an AUR package via https://aur.archlinux.org/packages/terrahelp 
+The community has also made it available as a [Terrahelp AUR package](https://aur.archlinux.org/packages/terrahelp) 
 
 #### OSX, Linux & *BSD
 
@@ -68,41 +68,81 @@ And run it:
 
 #### Windows
 
-Not here yet ...
+Not yet supported
 
-### Build it yourself  
+## Build from source
 
-To set up your Go environment - look [here](https://golang.org/doc/code.html).
+### Prerequisites
 
-Install Go (Terrahelp is currently built against 1.7.3)
+Install Go (Terrahelp is currently built against 1.13.x).  The following official resources will guide you through your environment setup. 
 
-    mkdir -p "$GOPATH/src/github.com/opencredo/"
-    git clone https://github.com/opencredo/terrahelp.git "$GOPATH/src/github.com/opencredo/terrahelp"
-    cd "$GOPATH/src/github.com/opencredo/terrahelp"
+* [Getting Started](https://golang.org/doc/install)
+* [Go Documentation](https://golang.org/doc)
 
-*Dependencies*
+Clone the Terrahelp repository.
 
-Terrahelp uses [govendor](https://github.com/kardianos/govendor) to manage it's dependencies, and currently also checks them into Git to enable a seamless build experience. However should you wish to change / upgrade any of these, you can get govendor, and then run the appropriate commands (e.g sync, fetch etc)
+```bash
+mkdir -p "$GOPATH/src/github.com/opencredo/"
+git clone https://github.com/opencredo/terrahelp.git "$GOPATH/src/github.com/opencredo/terrahelp"
+cd "$GOPATH/src/github.com/opencredo/terrahelp"
+```
 
-    go get -u github.com/kardianos/govendor
-    govendor sync
+### Dependencies
 
-*Build it*
+Terrahelp uses Go modules to manage it's dependencies.  During Go's transition to switching on modules by default, Terrahelp is setup to buildusing the vendor directory.
+Supportive targets are prvoided to allow the vendor directory to be recreated if required.
 
-    go install
+### Building and Executing
+
+After a build has completed successfully a binary will be built and placed into a local bin directory.  The following commands build and execute terrahelp.
+
+    make build
+    ./bin/terrahelp -v 
     
-*Test it*
+### Testing
     
-    go test -v ./...
+    make test
 
-*Run it:*
+### Installing and Executing
 
-    terrahelp -v 
-    
-*Want to cross compile it?*
+Assuming that your Go environment is setup correctly, an installed binary will be placed in your $GOPATH/bin directory.
+The following commands install and execute Terrahelp.
 
-    env GOOS=darwin GOARCH=amd64 go build -o=terrahelp-darwin-amd64
-    env GOOS=linux GOARCH=amd64 go build -o=terrahelp-linux-amd64
+    make install
+    terrahelp -v
+
+### Want to cross compile it?* 
+
+The make file allows both OSX and Linux binaries to be created at the same time or individually.  
+The following commands show joint creation followed by OSX, (darwin) then Linux creation.  All cross compiled binaries will be placed in a `dist` directory.
+
+    make dist
+    make darwin
+    make linux
+
+### Clean your project
+
+A number of work directories will have been created through the previous build steps. The local `bin` and `dist` directories will contain binaries.
+The following command can be used to return the project back to a pre build state.
+
+    make clean
+
+### Dependency management
+
+The following targets have been created to allow dependencies to be managed through Go modules.  As mentioned before Terrahelp builds using the vendor directory.
+
+* `make dependencies`
+  * Downloads the dependecies to the Go modules cache.
+* `make tidy-dependencies`
+  * Adds missing and removes unused modules.
+* `make vendor-dependencies`
+  * Copies the dependencies into the local vendor directory.
+* `make clean-dependencies`
+  * Removes the local vendor directory.
+  
+**NOTE:**  The Makefile defines a variable called `BUILDARGS` and this is currently set with `-mod=vendor`.  This instructs various go commands to use the vendor directory.  This can be overridden to build to project using standard go module flows.
+
+    BUILDARGS='' make build
 
 [Travis-Image]: https://travis-ci.org/opencredo/terrahelp.svg?branch=master
 [Travis-Url]: https://travis-ci.org/opencredo/terrahelp

--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ After a build has completed successfully a binary will be built and placed into 
 
 ### Installing and Executing
 
-Assuming that your Go environment is setup correctly, an installed binary will be placed in your $GOPATH/bin directory.
-The following commands install and execute Terrahelp.
+Installation places the binary in the `$GOPATH/bin` directory. Assuming that the directory has been added to your `PATH`, the following commands will install and execute Terrahelp.
 
     make install
     terrahelp -v


### PR DESCRIPTION
This PR is focused on the introduction of new make targets to help manage the build, install and distribution of Terrahelp.  These new targets include clean, install, uninstall, dist, (linux, darwin as dynamic targets).  A group of dependency related targets have been created to allow the vendor directory to be managed, (clean, tidy and download).

The binaries are built into the a new bin directory and the distributions are built into a dist directory.  This allows the created binaries to be kept separate from the project.  The travis file has been updated to locate the correct dist binaries and upload them to the release as expected.

The targets also represent a means to reset the project, (think along the lines of mvn and gradle with their target directories).