### PR TITLE
Add instruction for removing quarantine on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ And run it:
 
     terrahelp -help
 
+##### OSX Additional Step
+
+`terrahelp` may be prevented from running if you downloaded it using a web browser. To fix this, remove the quarantine attribute before running again:
+ 
+    xattr -d com.apple.quarantine terrahelp
+
 #### Windows
 
 Not here yet ...


### PR DESCRIPTION
Downloads via a browser attach metadata to prevent execution. The instruction clears that metadata.