### PR TITLE
Corrects missed TARGET reference stopping release uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ deploy:
     - dist/$NAME-*
   skip_cleanup: true
   on:
-    repo: opencredo/$TARGET
+    repo: opencredo/$NAME
     tags: true
     condition: $TRAVIS_GO_VERSION =~ ^1\.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.7.3 (unreleased)
+* [PR-30](https://github.com/opencredo/terrahelp/pull/30) Updates Travis CI file to replace missed TRAGET reference with NAME to allow release uploads (resolves [#29](https://github.com/opencredo/terrahelp/issues/29))
 
 ## 0.7.2
 * [PR-23](https://github.com/opencredo/terrahelp/pull/23) Update Terrahelp to process HCL2 syntax, (including tests and examples) (resolves [#22](https://github.com/opencredo/terrahelp/issues/22))


### PR DESCRIPTION
This PR corrects a missed reference to the old TARGET variable that represented the binary name.  In release 0.7.2 a build refactor was completed, but review missed this issue.