### PR TITLE
Introducing sha256 release values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ deploy:
   file_glob: true
   file:
     - dist/$NAME-*
+    - dist/$NAME-*.sha256
   skip_cleanup: true
   on:
     repo: opencredo/$NAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ deploy:
   file_glob: true
   file:
     - dist/$NAME-*
-    - dist/$NAME-*.sha256
+    - dist/$NAME.SHA256SUMS
   skip_cleanup: true
   on:
     repo: opencredo/$NAME

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.7.4 (unreleased)
+* [PR-31](https://github.com/opencredo/terrahelp/pull/31) Introduces sha256sum file covering each distribution binary (resolves [#28](https://github.com/opencredo/terrahelp/issues/28))
 
 ## 0.7.3
 * [PR-30](https://github.com/opencredo/terrahelp/pull/30) Updates Travis CI file to replace missed TRAGET reference with NAME to allow release uploads (resolves [#29](https://github.com/opencredo/terrahelp/issues/29))

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ PLATFORMS ?= darwin linux
 ARCH ?= amd64
 OS = $(word 1, $@)
 
+SHA256_CMD = sha256sum
+ifeq ($(shell uname), Darwin)
+	SHA256_CMD = shasum -a 256
+endif
+
 .PHONY: ensure-version
 ensure-version:
 ifeq ($(SKIP_GO_REQ_VERSION_CHECK),1)
@@ -67,12 +72,15 @@ $(PLATFORMS): ensure-version check test
 	@ echo "==> Building $(OS) distribution"
 	@ mkdir -p $(BIN)/$(OS)/$(ARCH)
 	@ mkdir -p $(DIST)
+
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build $(BUILDARGS) -o $(BIN)/$(OS)/$(ARCH)/$(NAME)
 	cp -f $(BIN)/$(OS)/$(ARCH)/$(NAME) $(DIST)/$(NAME)-$(OS)-$(ARCH)
 
+	$(SHA256_CMD) $(DIST)/$(NAME)-$(OS)-$(ARCH) | awk '{$$2="$(NAME)-$(OS)-$(ARCH)"; print $$0}' >> $(DIST)/$(NAME).SHA256SUMS
+
 .PHONY: dist
 dist: $(PLATFORMS)
-	@ true
+	@ touch $(DIST)/$(NAME).SHA256SUMS
 
 .PHONY: dependencies
 dependencies:

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ $(PLATFORMS): ensure-version check test
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build $(BUILDARGS) -o $(BIN)/$(OS)/$(ARCH)/$(NAME)
 	cp -f $(BIN)/$(OS)/$(ARCH)/$(NAME) $(DIST)/$(NAME)-$(OS)-$(ARCH)
 
-	@ $(SHA256_CMD) $(DIST)/$(NAME)-$(OS)-$(ARCH) | awk '{$$2="$(NAME)-$(OS)-$(ARCH)"; print $$0}' >> $(DIST)/$(NAME).SHA256SUMS
+	@ $(SHA256_CMD) $(DIST)/$(NAME)-$(OS)-$(ARCH) | awk '{$$2=" $(NAME)-$(OS)-$(ARCH)"; print $$0}' >> $(DIST)/$(NAME).SHA256SUMS
 
 .PHONY: dist
 dist: $(PLATFORMS)

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ $(PLATFORMS): ensure-version check test
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build $(BUILDARGS) -o $(BIN)/$(OS)/$(ARCH)/$(NAME)
 	cp -f $(BIN)/$(OS)/$(ARCH)/$(NAME) $(DIST)/$(NAME)-$(OS)-$(ARCH)
 
-	$(SHA256_CMD) $(DIST)/$(NAME)-$(OS)-$(ARCH) | awk '{$$2="$(NAME)-$(OS)-$(ARCH)"; print $$0}' >> $(DIST)/$(NAME).SHA256SUMS
+	@ $(SHA256_CMD) $(DIST)/$(NAME)-$(OS)-$(ARCH) | awk '{$$2="$(NAME)-$(OS)-$(ARCH)"; print $$0}' >> $(DIST)/$(NAME).SHA256SUMS
 
 .PHONY: dist
 dist: $(PLATFORMS)


### PR DESCRIPTION
This PR works to resolve issue [#28](https://github.com/opencredo/terrahelp/issues/28) by calculating sha256 hashes against each of the terrahelp binaries that are produced.

A single file called terrahelp.SHA256SUMS is created along side the existing terrahelp-darwin-amd64 and terrahelp-linux-amd64 binaries.  Each line contains a hash value and the binary it corresponds to.

A tagged release will include each of the binaries and the new sha256sum file for user to verify their download.

The PR takes its inspiration from https://releases.hashicorp.com
If we look at the latest Terraform release it gives a good example that is used across all of their released software.  https://releases.hashicorp.com/terraform/0.12.17