### PR TITLE
Add Brew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@
 # Terrahelp
 ##### Terraforming, with a little help from your friends
 
-Terrahelp is as a command line utility written in [Go](https://golang.org) and is aimed at 
-providing supplementary functionality which can sometimes prove useful when working with 
-[Terraform](https://www.terraform.io). 
+Terrahelp is as a command line utility written in [Go](https://golang.org) and is aimed at
+providing supplementary functionality which can sometimes prove useful when working with
+[Terraform](https://www.terraform.io).
 
 At present, it offers the following:
 
 * _Encryption & decryption functionality_.
 Run in either full or inline mode, and leveraging either a simple or [Vault](https://www.vaultproject.io) based encryption provider, this
-functionality provides the ability to encrypt and decrypt files such as terraform.tfstate files, as well as piped in 
-output from commands such as terraform apply etc. 
+functionality provides the ability to encrypt and decrypt files such as terraform.tfstate files, as well as piped in
+output from commands such as terraform apply etc.
 
 * _Masking functionality_.
 If you don't want to encrypt sensitive data, but rather just mask it out with something like ***** then you can use
 the mask command instead. This can either be run over a file, or have the content piped into it.
 
-For more details, and some examples of how to use it please see [the example READMEs](https://github.com/opencredo/terrahelp/tree/master/examples). 
+For more details, and some examples of how to use it please see [the example READMEs](https://github.com/opencredo/terrahelp/tree/master/examples).
 
 Additionally the blog post [Securing Terraform State with Vault](https://www.opencredo.com/securing-terraform-state-with-vault) also provides more details and background as well.
 
@@ -41,7 +41,7 @@ Additionally the blog post [Securing Terraform State with Vault](https://www.ope
             decrypt		        Uses configured provider to decrypt specified content
             mask                    Mask will overwrite sensitive data in output or files with a masked value (eg. ******).
             help, h                 Shows a list of commands or help for one command
-            
+
         GLOBAL OPTIONS:
            --help, -h		show help
            --version, -v	print the version
@@ -49,13 +49,20 @@ Additionally the blog post [Securing Terraform State with Vault](https://www.ope
 
 ## Installation
 
-### Pre-built binaries
+### macOS
+
+Install using [Homebrew](https://brew.sh/):
+
+    brew install terrahelp
+    terrahelp -v
+
+### Manual Installation Using the Pre-Built Binaries
 
 Available from the Terrahelp repository's [releases page](https://github.com/opencredo/terrahelp/releases)
 
-The community has also made it available as a [Terrahelp AUR package](https://aur.archlinux.org/packages/terrahelp) 
+The community has also made it available as a [Terrahelp AUR package](https://aur.archlinux.org/packages/terrahelp)
 
-#### OSX, Linux & *BSD
+#### macOS, Linux & *BSD
 
 Download a binary, set the correct permissions, add to your PATH:
 
@@ -64,12 +71,12 @@ Download a binary, set the correct permissions, add to your PATH:
 
 And run it:
 
-    terrahelp -help
+    terrahelp --help
 
-##### OSX Additional Step
+##### macOS Additional Step
 
 `terrahelp` may be prevented from running if you downloaded it using a web browser. To fix this, remove the quarantine attribute before running again:
- 
+
     xattr -d com.apple.quarantine terrahelp
 
 #### Windows
@@ -80,7 +87,7 @@ Not yet supported
 
 ### Prerequisites
 
-Install Go (Terrahelp is currently built against 1.13.x).  The following official resources will guide you through your environment setup. 
+Install Go (Terrahelp is currently built against 1.13.x).  The following official resources will guide you through your environment setup.
 
 * [Getting Started](https://golang.org/doc/install)
 * [Go Documentation](https://golang.org/doc)
@@ -103,10 +110,10 @@ Supportive targets are prvoided to allow the vendor directory to be recreated if
 After a build has completed successfully a binary will be built and placed into a local bin directory.  The following commands build and execute terrahelp.
 
     make build
-    ./bin/terrahelp -v 
-    
+    ./bin/terrahelp -v
+
 ### Testing
-    
+
     make test
 
 ### Installing and Executing
@@ -116,9 +123,9 @@ Installation places the binary in the `$GOPATH/bin` directory. Assuming that the
     make install
     terrahelp -v
 
-### Want to cross compile it?* 
+### Want to cross compile it?
 
-The make file allows both OSX and Linux binaries to be created at the same time or individually.  
+The make file allows both OSX and Linux binaries to be created at the same time or individually.
 The following commands show joint creation followed by OSX, (darwin) then Linux creation.  All cross compiled binaries will be placed in a `dist` directory.
 
     make dist
@@ -137,19 +144,30 @@ The following command can be used to return the project back to a pre build stat
 The following targets have been created to allow dependencies to be managed through Go modules.  As mentioned before Terrahelp builds using the vendor directory.
 
 * `make dependencies`
-  * Downloads the dependecies to the Go modules cache.
+  * Downloads the dependencies to the Go modules cache.
 * `make tidy-dependencies`
   * Adds missing and removes unused modules.
 * `make vendor-dependencies`
   * Copies the dependencies into the local vendor directory.
 * `make clean-dependencies`
   * Removes the local vendor directory.
-  
+
 **NOTE:**  The Makefile defines a variable called `BUILDARGS` and this is currently set with `-mod=vendor`.  This instructs various go commands to use the vendor directory.  This can be overridden to build to project using standard go module flows.
 
     BUILDARGS='' make build
+
+## Releasing
+
+### Brew
+***NOTE:*** This step should be performed *after* a new version of `terrahelp` has been released.
+
+Follow the instructions outlined in [Submit a new version of an existing formula][Homebrew-Update-Formula] to update the version of `terrahelp` installed by Brew.
+
+For reference, the formula can be viewed in the homebrew-core repository [here][Terrahelp-Formula].
 
 [Travis-Image]: https://travis-ci.org/opencredo/terrahelp.svg?branch=master
 [Travis-Url]: https://travis-ci.org/opencredo/terrahelp
 [ReportCard-Url]: http://goreportcard.com/report/opencredo/terrahelp
 [ReportCard-Image]: http://goreportcard.com/badge/opencredo/terrahelp
+[Homebrew-Update-Formula]: https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request#submit-a-new-version-of-an-existing-formula
+[Terrahelp-Formula]: https://github.com/Homebrew/homebrew-core/blob/master/Formula/terrahelp.rb


### PR DESCRIPTION
Also, add instructions for updating Brew when a new version of `terrahelp` is released.

Includes other small fixes, and also, my editor removed some whitespace – so it looks like much more has changed in the diff than actually has.

Also, the "raw" rending of the markdown makes it look like a large section of the document is in bold, however this is not the case. If you look at the rendered version it is fine...!