### PR TITLE
Remove quoted types in variables for tf > 0.11 support

### DIFF
--- a/examples/mask/variables.tf
+++ b/examples/mask/variables.tf
@@ -9,11 +9,12 @@ variable "tf_sensitive_key_3"     {}
 variable "tf_sensitive_key_4"     {}
 variable "tf_sensitive_key_6"     {}
 
-variable "tf_sensitive_list_vals"       { type = "list" }
-variable "tf_sensitive_flatmap_vals"    { type = "map"  }
+variable "tf_sensitive_list_vals"       { type = list(string) }
+variable "tf_sensitive_flatmap_vals"    { type = map(string)  }
 
 # ----------------------------------------------------------------
 # Non sensitive variable defaults
 # ----------------------------------------------------------------
 variable "tf_normal_key_1"     { default = "normal value 1" }
 variable "tf_normal_key_2"     { default = "normal value 2" }
+

--- a/examples/tfstate-encrypt/variables.tf
+++ b/examples/tfstate-encrypt/variables.tf
@@ -9,11 +9,12 @@ variable "tf_sensitive_key_3"     {}
 variable "tf_sensitive_key_4"     {}
 variable "tf_sensitive_key_6"     {}
 
-variable "tf_sensitive_list_vals"       { type = "list" }
-variable "tf_sensitive_flatmap_vals"    { type = "map"  }
+variable "tf_sensitive_list_vals"       { type = list(string) }
+variable "tf_sensitive_flatmap_vals"    { type = map(string)  }
 
 # ----------------------------------------------------------------
 # Non sensitive variable defaults
 # ----------------------------------------------------------------
 variable "tf_normal_key_1"     { default = "normal value 1" }
 variable "tf_normal_key_2"     { default = "normal value 2" }
+


### PR DESCRIPTION
Hi there 👋 ,

in this PR, we've removed quoted types in the `variables.tf` files to make `examples/` to work with the latest version of Terraform.
With these changes, we should be able to run `terraform init` without any errors.